### PR TITLE
Chore: fix problem run app in windows

### DIFF
--- a/apps/booking-app/.babelrc
+++ b/apps/booking-app/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["next/babel"]
+}


### PR DESCRIPTION
By default Next.js uses Rust-based compiler SWC but in windows is generate problems when we run the aoo, reading the documentation they propose add the next/babel preset in babel config

[Next JS problem doc](https://nextjs.org/docs/messages/failed-loading-swc)