### PR TITLE
fix(messages): add username above message

### DIFF
--- a/packages/messaging-system/src/components/Chat/Chat.jsx
+++ b/packages/messaging-system/src/components/Chat/Chat.jsx
@@ -167,7 +167,7 @@ function Chat({ customerId, chatId }) {
                 group.messages.map((message) => (
                   <Message
                     key={message._id}
-                    name={message.name}
+                    name={message.createdBy === customerId ? 'Yo' : 'John Doe'}
                     text={message.text}
                     avatarUrl="https://cdn.pixabay.com/photo/2016/12/13/05/15/cat-1903313_960_720.jpg"
                     createdBy={message.createdBy}


### PR DESCRIPTION
# Description
I forgot to add the username above the message in a previous PR, so this add that property.

# Changes
- Resolves #227 

# Preview
![Screen Shot 2022-06-05 at 18 07 59](https://user-images.githubusercontent.com/28733681/172078832-48c4a195-2955-4fe9-8c7f-431e6a587415.png)

